### PR TITLE
Fix audit-service JSONB column type mismatch

### DIFF
--- a/services/audit-service/src/main/java/com/microbank/audit/model/AuditLog.java
+++ b/services/audit-service/src/main/java/com/microbank/audit/model/AuditLog.java
@@ -1,14 +1,14 @@
 package com.microbank.audit.model;
 
-import com.microbank.audit.converter.JsonbConverter;
 import jakarta.persistence.Column;
-import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 import java.time.LocalDateTime;
 import java.util.Map;
@@ -34,7 +34,7 @@ public class AuditLog {
     @Column(name = "user_id")
     private UUID userId;
 
-    @Convert(converter = JsonbConverter.class)
+    @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "details", columnDefinition = "jsonb")
     private Map<String, Object> details;
 


### PR DESCRIPTION
## Summary
- **Bug**: The `details` column in `audit_logs` is `jsonb`, but the custom `JsonbConverter` was sending the value as `varchar`, causing PostgreSQL error `42804` on every audit log insert.
- **Fix**: Replaced `@Convert(converter = JsonbConverter.class)` with Hibernate 6's native `@JdbcTypeCode(SqlTypes.JSON)`, which sends the correct JDBC type for JSONB columns.

## Test plan
- [ ] Redeploy audit-service to K8s
- [ ] Trigger a money transfer and verify audit log is persisted without errors
- [ ] Check `kubectl logs` for the audit-service pod — no more `column "details" is of type jsonb but expression is of type character varying` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)