### PR TITLE
Add OpenTelemetry pipeline with Honeycomb backend

### DIFF
--- a/.github/workflows/reusable-go.yml
+++ b/.github/workflows/reusable-go.yml
@@ -63,7 +63,6 @@ jobs:
 
   build-and-push:
     name: Build & Push
-    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: test
     permissions:
@@ -79,12 +78,21 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push image
-        working-directory: ${{ inputs.service_path }}
-        env:
-          IMAGE_TAG: ${{ env.REGISTRY }}/${{ github.repository_owner }}/microbank-${{ inputs.service_name }}:${{ github.sha }}
-          IMAGE_LATEST: ${{ env.REGISTRY }}/${{ github.repository_owner }}/microbank-${{ inputs.service_name }}:latest
+      - name: Compute image tags
+        id: tags
         run: |
-          docker build -t $IMAGE_TAG -t $IMAGE_LATEST .
-          docker push $IMAGE_TAG
-          docker push $IMAGE_LATEST
+          BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
+          BRANCH_TAG=$(echo "$BRANCH" | tr '/_' '--' | tr -cd 'a-zA-Z0-9.-')
+          IMG="${{ env.REGISTRY }}/${{ github.repository_owner }}/microbank-${{ inputs.service_name }}"
+          TAGS="$IMG:${{ github.sha }},$IMG:branch-$BRANCH_TAG"
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            TAGS="$TAGS,$IMG:latest"
+          fi
+          echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ inputs.service_path }}
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}

--- a/.github/workflows/reusable-python.yml
+++ b/.github/workflows/reusable-python.yml
@@ -64,7 +64,6 @@ jobs:
 
   build-and-push:
     name: Build & Push
-    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: test
     permissions:
@@ -80,12 +79,21 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push image
-        working-directory: ${{ inputs.service_path }}
-        env:
-          IMAGE_TAG: ${{ env.REGISTRY }}/${{ github.repository_owner }}/microbank-${{ inputs.service_name }}:${{ github.sha }}
-          IMAGE_LATEST: ${{ env.REGISTRY }}/${{ github.repository_owner }}/microbank-${{ inputs.service_name }}:latest
+      - name: Compute image tags
+        id: tags
         run: |
-          docker build -t $IMAGE_TAG -t $IMAGE_LATEST .
-          docker push $IMAGE_TAG
-          docker push $IMAGE_LATEST
+          BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
+          BRANCH_TAG=$(echo "$BRANCH" | tr '/_' '--' | tr -cd 'a-zA-Z0-9.-')
+          IMG="${{ env.REGISTRY }}/${{ github.repository_owner }}/microbank-${{ inputs.service_name }}"
+          TAGS="$IMG:${{ github.sha }},$IMG:branch-$BRANCH_TAG"
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            TAGS="$TAGS,$IMG:latest"
+          fi
+          echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ inputs.service_path }}
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}

--- a/.github/workflows/reusable-react.yml
+++ b/.github/workflows/reusable-react.yml
@@ -54,7 +54,6 @@ jobs:
 
   build-and-push:
     name: Build & Push
-    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: test
     permissions:
@@ -70,12 +69,21 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push image
-        working-directory: ${{ inputs.service_path }}
-        env:
-          IMAGE_TAG: ${{ env.REGISTRY }}/${{ github.repository_owner }}/microbank-${{ inputs.service_name }}:${{ github.sha }}
-          IMAGE_LATEST: ${{ env.REGISTRY }}/${{ github.repository_owner }}/microbank-${{ inputs.service_name }}:latest
+      - name: Compute image tags
+        id: tags
         run: |
-          docker build -t $IMAGE_TAG -t $IMAGE_LATEST .
-          docker push $IMAGE_TAG
-          docker push $IMAGE_LATEST
+          BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
+          BRANCH_TAG=$(echo "$BRANCH" | tr '/_' '--' | tr -cd 'a-zA-Z0-9.-')
+          IMG="${{ env.REGISTRY }}/${{ github.repository_owner }}/microbank-${{ inputs.service_name }}"
+          TAGS="$IMG:${{ github.sha }},$IMG:branch-$BRANCH_TAG"
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            TAGS="$TAGS,$IMG:latest"
+          fi
+          echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ inputs.service_path }}
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}

--- a/.github/workflows/reusable-spring-java.yml
+++ b/.github/workflows/reusable-spring-java.yml
@@ -88,7 +88,6 @@ jobs:
 
   build-and-push:
     name: Build & Push
-    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: test
     permissions:
@@ -104,12 +103,21 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push image
-        working-directory: ${{ inputs.service_path }}
-        env:
-          IMAGE_TAG: ${{ env.REGISTRY }}/${{ github.repository_owner }}/microbank-${{ inputs.service_name }}:${{ github.sha }}
-          IMAGE_LATEST: ${{ env.REGISTRY }}/${{ github.repository_owner }}/microbank-${{ inputs.service_name }}:latest
+      - name: Compute image tags
+        id: tags
         run: |
-          docker build -t $IMAGE_TAG -t $IMAGE_LATEST .
-          docker push $IMAGE_TAG
-          docker push $IMAGE_LATEST
+          BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
+          BRANCH_TAG=$(echo "$BRANCH" | tr '/_' '--' | tr -cd 'a-zA-Z0-9.-')
+          IMG="${{ env.REGISTRY }}/${{ github.repository_owner }}/microbank-${{ inputs.service_name }}"
+          TAGS="$IMG:${{ github.sha }},$IMG:branch-$BRANCH_TAG"
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            TAGS="$TAGS,$IMG:latest"
+          fi
+          echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ inputs.service_path }}
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}

--- a/.github/workflows/reusable-spring-kotlin.yml
+++ b/.github/workflows/reusable-spring-kotlin.yml
@@ -88,7 +88,6 @@ jobs:
 
   build-and-push:
     name: Build & Push
-    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: test
     permissions:
@@ -104,12 +103,21 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push image
-        working-directory: ${{ inputs.service_path }}
-        env:
-          IMAGE_TAG: ${{ env.REGISTRY }}/${{ github.repository_owner }}/microbank-${{ inputs.service_name }}:${{ github.sha }}
-          IMAGE_LATEST: ${{ env.REGISTRY }}/${{ github.repository_owner }}/microbank-${{ inputs.service_name }}:latest
+      - name: Compute image tags
+        id: tags
         run: |
-          docker build -t $IMAGE_TAG -t $IMAGE_LATEST .
-          docker push $IMAGE_TAG
-          docker push $IMAGE_LATEST
+          BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
+          BRANCH_TAG=$(echo "$BRANCH" | tr '/_' '--' | tr -cd 'a-zA-Z0-9.-')
+          IMG="${{ env.REGISTRY }}/${{ github.repository_owner }}/microbank-${{ inputs.service_name }}"
+          TAGS="$IMG:${{ github.sha }},$IMG:branch-$BRANCH_TAG"
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            TAGS="$TAGS,$IMG:latest"
+          fi
+          echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ inputs.service_path }}
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}

--- a/helm/microbank/charts/account-service/templates/deployment.yaml
+++ b/helm/microbank/charts/account-service/templates/deployment.yaml
@@ -48,6 +48,18 @@ spec:
                 secretKeyRef:
                   name: {{ .Release.Name }}-db-credentials
                   key: password
+            {{- if .Values.global.otel.enabled }}
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{ .Values.global.otel.endpoint | quote }}
+            - name: OTEL_SERVICE_NAME
+              value: "account-service"
+            - name: OTEL_TRACES_EXPORTER
+              value: "otlp"
+            - name: OTEL_METRICS_EXPORTER
+              value: "otlp"
+            - name: OTEL_LOGS_EXPORTER
+              value: "otlp"
+            {{- end }}
           startupProbe:
             httpGet:
               path: /actuator/health

--- a/helm/microbank/charts/account-service/templates/deployment.yaml
+++ b/helm/microbank/charts/account-service/templates/deployment.yaml
@@ -59,6 +59,8 @@ spec:
               value: "otlp"
             - name: OTEL_LOGS_EXPORTER
               value: "otlp"
+            - name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: "http/protobuf"
             {{- end }}
           startupProbe:
             httpGet:

--- a/helm/microbank/charts/api-gateway/templates/deployment.yaml
+++ b/helm/microbank/charts/api-gateway/templates/deployment.yaml
@@ -40,6 +40,12 @@ spec:
               value: {{ printf "http://%s-transaction-service:8083" .Release.Name | quote }}
             - name: EXCHANGE_SERVICE_URL
               value: {{ printf "http://%s-exchange-service:8085" .Release.Name | quote }}
+            {{- if .Values.global.otel.enabled }}
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{ .Values.global.otel.endpoint | quote }}
+            - name: OTEL_SERVICE_NAME
+              value: "api-gateway"
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/helm/microbank/charts/audit-service/templates/deployment.yaml
+++ b/helm/microbank/charts/audit-service/templates/deployment.yaml
@@ -59,6 +59,8 @@ spec:
               value: "otlp"
             - name: OTEL_LOGS_EXPORTER
               value: "otlp"
+            - name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: "http/protobuf"
             {{- end }}
           startupProbe:
             httpGet:

--- a/helm/microbank/charts/audit-service/templates/deployment.yaml
+++ b/helm/microbank/charts/audit-service/templates/deployment.yaml
@@ -48,6 +48,18 @@ spec:
                 secretKeyRef:
                   name: {{ .Release.Name }}-db-credentials
                   key: password
+            {{- if .Values.global.otel.enabled }}
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{ .Values.global.otel.endpoint | quote }}
+            - name: OTEL_SERVICE_NAME
+              value: "audit-service"
+            - name: OTEL_TRACES_EXPORTER
+              value: "otlp"
+            - name: OTEL_METRICS_EXPORTER
+              value: "otlp"
+            - name: OTEL_LOGS_EXPORTER
+              value: "otlp"
+            {{- end }}
           startupProbe:
             httpGet:
               path: /actuator/health

--- a/helm/microbank/charts/auth-service/templates/deployment.yaml
+++ b/helm/microbank/charts/auth-service/templates/deployment.yaml
@@ -48,6 +48,12 @@ spec:
                 secretKeyRef:
                   name: {{ .Release.Name }}-db-credentials
                   key: password
+            {{- if .Values.global.otel.enabled }}
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{ .Values.global.otel.endpoint | quote }}
+            - name: OTEL_SERVICE_NAME
+              value: "auth-service"
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/helm/microbank/charts/exchange-service/templates/deployment.yaml
+++ b/helm/microbank/charts/exchange-service/templates/deployment.yaml
@@ -32,6 +32,12 @@ spec:
           env:
             - name: PORT
               value: "8085"
+            {{- if .Values.global.otel.enabled }}
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{ .Values.global.otel.endpoint | quote }}
+            - name: OTEL_SERVICE_NAME
+              value: "exchange-service"
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/helm/microbank/charts/fraud-service/templates/deployment.yaml
+++ b/helm/microbank/charts/fraud-service/templates/deployment.yaml
@@ -32,6 +32,12 @@ spec:
           env:
             - name: PORT
               value: "8084"
+            {{- if .Values.global.otel.enabled }}
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{ .Values.global.otel.endpoint | quote }}
+            - name: OTEL_SERVICE_NAME
+              value: "fraud-service"
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/helm/microbank/charts/notification-service/templates/deployment.yaml
+++ b/helm/microbank/charts/notification-service/templates/deployment.yaml
@@ -32,6 +32,12 @@ spec:
           env:
             - name: PORT
               value: "8086"
+            {{- if .Values.global.otel.enabled }}
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{ .Values.global.otel.endpoint | quote }}
+            - name: OTEL_SERVICE_NAME
+              value: "notification-service"
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/helm/microbank/charts/transaction-service/templates/deployment.yaml
+++ b/helm/microbank/charts/transaction-service/templates/deployment.yaml
@@ -58,6 +58,18 @@ spec:
               value: {{ printf "http://%s-notification-service:8086" .Release.Name | quote }}
             - name: AUDIT_SERVICE_URL
               value: {{ printf "http://%s-audit-service:8087" .Release.Name | quote }}
+            {{- if .Values.global.otel.enabled }}
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{ .Values.global.otel.endpoint | quote }}
+            - name: OTEL_SERVICE_NAME
+              value: "transaction-service"
+            - name: OTEL_TRACES_EXPORTER
+              value: "otlp"
+            - name: OTEL_METRICS_EXPORTER
+              value: "otlp"
+            - name: OTEL_LOGS_EXPORTER
+              value: "otlp"
+            {{- end }}
           startupProbe:
             httpGet:
               path: /actuator/health

--- a/helm/microbank/charts/transaction-service/templates/deployment.yaml
+++ b/helm/microbank/charts/transaction-service/templates/deployment.yaml
@@ -69,6 +69,8 @@ spec:
               value: "otlp"
             - name: OTEL_LOGS_EXPORTER
               value: "otlp"
+            - name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: "http/protobuf"
             {{- end }}
           startupProbe:
             httpGet:

--- a/helm/microbank/values.yaml
+++ b/helm/microbank/values.yaml
@@ -9,7 +9,7 @@ global:
     username: microbank
     password: microbank
   serviceMesh:
-    enabled: true
+    enabled: false
   prometheus:
     enabled: true
   otel:

--- a/helm/microbank/values.yaml
+++ b/helm/microbank/values.yaml
@@ -12,6 +12,9 @@ global:
     enabled: true
   prometheus:
     enabled: true
+  otel:
+    enabled: true
+    endpoint: "http://otel-otel-collector:4317"
 
 ingress:
   enabled: true

--- a/helm/microbank/values.yaml
+++ b/helm/microbank/values.yaml
@@ -9,7 +9,7 @@ global:
     username: microbank
     password: microbank
   serviceMesh:
-    enabled: false
+    enabled: true
   prometheus:
     enabled: true
   otel:

--- a/helm/microbank/values.yaml
+++ b/helm/microbank/values.yaml
@@ -14,7 +14,7 @@ global:
     enabled: true
   otel:
     enabled: true
-    endpoint: "http://otel-otel-collector:4317"
+    endpoint: "http://otel-otel-collector:4318"
 
 ingress:
   enabled: true

--- a/helm/otel/Chart.yaml
+++ b/helm/otel/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: otel
+description: OpenTelemetry Collector with Honeycomb backend for MicroBank
+type: application
+version: 0.1.0
+appVersion: "0.100.0"

--- a/helm/otel/templates/configmap.yaml
+++ b/helm/otel/templates/configmap.yaml
@@ -27,27 +27,34 @@ data:
             action: upsert
 
     exporters:
-      otlp/honeycomb:
-        endpoint: {{ .Values.honeycomb.endpoint }}
+      otlphttp/honeycomb:
+        endpoint: {{ .Values.honeycomb.endpoint | quote }}
         headers:
           x-honeycomb-team: "${env:HONEYCOMB_API_KEY}"
+      debug:
+        verbosity: basic
+        sampling_initial: 5
+        sampling_thereafter: 200
 
     extensions:
       health_check:
         endpoint: 0.0.0.0:13133
 
     service:
+      telemetry:
+        logs:
+          level: info
       extensions: [health_check]
       pipelines:
         traces:
           receivers: [otlp]
           processors: [batch, resource]
-          exporters: [otlp/honeycomb]
+          exporters: [otlphttp/honeycomb, debug]
         metrics:
           receivers: [otlp]
           processors: [batch, resource]
-          exporters: [otlp/honeycomb]
+          exporters: [otlphttp/honeycomb, debug]
         logs:
           receivers: [otlp]
           processors: [batch, resource]
-          exporters: [otlp/honeycomb]
+          exporters: [otlphttp/honeycomb, debug]

--- a/helm/otel/templates/configmap.yaml
+++ b/helm/otel/templates/configmap.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-otel-collector-config
+  namespace: {{ .Values.namespace }}
+data:
+  config.yaml: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+
+    processors:
+      batch:
+        timeout: 5s
+        send_batch_size: 1024
+      resource:
+        attributes:
+          - key: deployment.environment
+            value: {{ .Values.environment }}
+            action: upsert
+          - key: service.namespace
+            value: microbank
+            action: upsert
+
+    exporters:
+      otlp/honeycomb:
+        endpoint: {{ .Values.honeycomb.endpoint }}
+        headers:
+          x-honeycomb-team: "${env:HONEYCOMB_API_KEY}"
+
+    extensions:
+      health_check:
+        endpoint: 0.0.0.0:13133
+
+    service:
+      extensions: [health_check]
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: [batch, resource]
+          exporters: [otlp/honeycomb]
+        metrics:
+          receivers: [otlp]
+          processors: [batch, resource]
+          exporters: [otlp/honeycomb]
+        logs:
+          receivers: [otlp]
+          processors: [batch, resource]
+          exporters: [otlp/honeycomb]

--- a/helm/otel/templates/deployment.yaml
+++ b/helm/otel/templates/deployment.yaml
@@ -14,10 +14,8 @@ spec:
     metadata:
       labels:
         app: otel-collector
-      {{- if .Values.serviceMesh.enabled }}
       annotations:
-        sidecar.istio.io/inject: "true"
-      {{- end }}
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
         - name: otel-collector

--- a/helm/otel/templates/deployment.yaml
+++ b/helm/otel/templates/deployment.yaml
@@ -14,6 +14,10 @@ spec:
     metadata:
       labels:
         app: otel-collector
+      {{- if .Values.serviceMesh.enabled }}
+      annotations:
+        sidecar.istio.io/inject: "true"
+      {{- end }}
     spec:
       containers:
         - name: otel-collector

--- a/helm/otel/templates/deployment.yaml
+++ b/helm/otel/templates/deployment.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-otel-collector
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: otel-collector
+spec:
+  replicas: {{ .Values.otelCollector.replicas }}
+  selector:
+    matchLabels:
+      app: otel-collector
+  template:
+    metadata:
+      labels:
+        app: otel-collector
+    spec:
+      containers:
+        - name: otel-collector
+          image: {{ .Values.otelCollector.image }}
+          args:
+            - "--config=/etc/otelcol-contrib/config.yaml"
+          env:
+            - name: HONEYCOMB_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-honeycomb
+                  key: api-key
+          ports:
+            - name: otlp-grpc
+              containerPort: 4317
+              protocol: TCP
+            - name: otlp-http
+              containerPort: 4318
+              protocol: TCP
+            - name: metrics
+              containerPort: 8888
+              protocol: TCP
+            - name: health
+              containerPort: 13133
+              protocol: TCP
+          volumeMounts:
+            - name: config
+              mountPath: /etc/otelcol-contrib/config.yaml
+              subPath: config.yaml
+              readOnly: true
+          livenessProbe:
+            httpGet:
+              path: /
+              port: health
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: {{ .Values.otelCollector.resources.requests.cpu }}
+              memory: {{ .Values.otelCollector.resources.requests.memory }}
+            limits:
+              cpu: {{ .Values.otelCollector.resources.limits.cpu }}
+              memory: {{ .Values.otelCollector.resources.limits.memory }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ .Release.Name }}-otel-collector-config

--- a/helm/otel/templates/secret.yaml
+++ b/helm/otel/templates/secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-honeycomb
+  namespace: {{ .Values.namespace }}
+type: Opaque
+stringData:
+  api-key: {{ .Values.honeycomb.apiKey | quote }}

--- a/helm/otel/templates/service.yaml
+++ b/helm/otel/templates/service.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-otel-collector
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: otel-collector
+spec:
+  type: ClusterIP
+  selector:
+    app: otel-collector
+  ports:
+    - name: otlp-grpc
+      port: 4317
+      targetPort: otlp-grpc
+      protocol: TCP
+    - name: otlp-http
+      port: 4318
+      targetPort: otlp-http
+      protocol: TCP
+    - name: metrics
+      port: 8888
+      targetPort: metrics
+      protocol: TCP

--- a/helm/otel/templates/service.yaml
+++ b/helm/otel/templates/service.yaml
@@ -14,11 +14,14 @@ spec:
       port: 4317
       targetPort: otlp-grpc
       protocol: TCP
+      appProtocol: grpc
     - name: otlp-http
       port: 4318
       targetPort: otlp-http
       protocol: TCP
+      appProtocol: http
     - name: metrics
       port: 8888
       targetPort: metrics
       protocol: TCP
+      appProtocol: http

--- a/helm/otel/values.yaml
+++ b/helm/otel/values.yaml
@@ -1,0 +1,18 @@
+namespace: student-research
+
+otelCollector:
+  image: otel/opentelemetry-collector-contrib:0.100.0
+  replicas: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+honeycomb:
+  apiKey: ""
+  endpoint: "api.honeycomb.io:443"
+
+environment: development

--- a/helm/otel/values.yaml
+++ b/helm/otel/values.yaml
@@ -16,6 +16,6 @@ honeycomb:
   endpoint: "https://api.honeycomb.io"
 
 serviceMesh:
-  enabled: false
+  enabled: true
 
 environment: development

--- a/helm/otel/values.yaml
+++ b/helm/otel/values.yaml
@@ -13,9 +13,9 @@ otelCollector:
 
 honeycomb:
   apiKey: ""
-  endpoint: "api.honeycomb.io:443"
+  endpoint: "https://api.honeycomb.io"
 
 serviceMesh:
-  enabled: true
+  enabled: false
 
 environment: development

--- a/helm/otel/values.yaml
+++ b/helm/otel/values.yaml
@@ -16,6 +16,6 @@ honeycomb:
   endpoint: "https://api.honeycomb.io"
 
 serviceMesh:
-  enabled: true
+  enabled: false
 
 environment: development

--- a/helm/otel/values.yaml
+++ b/helm/otel/values.yaml
@@ -5,11 +5,11 @@ otelCollector:
   replicas: 1
   resources:
     requests:
-      cpu: 100m
-      memory: 256Mi
+      cpu: 25m
+      memory: 64Mi
     limits:
-      cpu: 500m
-      memory: 512Mi
+      cpu: 200m
+      memory: 128Mi
 
 honeycomb:
   apiKey: ""

--- a/helm/otel/values.yaml
+++ b/helm/otel/values.yaml
@@ -15,4 +15,7 @@ honeycomb:
   apiKey: ""
   endpoint: "api.honeycomb.io:443"
 
+serviceMesh:
+  enabled: true
+
 environment: development

--- a/k8s/istio/destination-rules.yaml
+++ b/k8s/istio/destination-rules.yaml
@@ -1,10 +1,21 @@
 apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
 metadata:
-  name: auth-service
+  name: microbank-mtls
   namespace: student-research
 spec:
   host: "*.student-research.svc.cluster.local"
   trafficPolicy:
     tls:
       mode: ISTIO_MUTUAL
+---
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: otel-collector-plaintext
+  namespace: student-research
+spec:
+  host: otel-otel-collector.student-research.svc.cluster.local
+  trafficPolicy:
+    tls:
+      mode: DISABLE

--- a/k8s/istio/peer-authentication-strict.yaml
+++ b/k8s/istio/peer-authentication-strict.yaml
@@ -66,3 +66,15 @@ spec:
   portLevelMtls:
     "9090":
       mode: PERMISSIVE
+---
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: otel-collector-plaintext
+  namespace: student-research
+spec:
+  selector:
+    matchLabels:
+      app: otel-collector
+  mtls:
+    mode: PERMISSIVE

--- a/k8s/istio/telemetry-otel.yaml
+++ b/k8s/istio/telemetry-otel.yaml
@@ -1,0 +1,10 @@
+apiVersion: telemetry.istio.io/v1alpha1
+kind: Telemetry
+metadata:
+  name: microbank-tracing
+  namespace: student-research
+spec:
+  tracing:
+    - providers:
+        - name: otel-collector
+      randomSamplingPercentage: 100

--- a/k8s/istio/telemetry-otel.yaml
+++ b/k8s/istio/telemetry-otel.yaml
@@ -8,3 +8,16 @@ spec:
     - providers:
         - name: otel-collector
       randomSamplingPercentage: 100
+      customTags:
+        source_workload:
+          environment:
+            name: WORKLOAD_NAME
+        source_namespace:
+          environment:
+            name: POD_NAMESPACE
+        source_service_account:
+          environment:
+            name: SERVICE_ACCOUNT
+        mesh_id:
+          environment:
+            name: ISTIO_META_MESH_ID

--- a/services/account-service/Dockerfile
+++ b/services/account-service/Dockerfile
@@ -7,5 +7,6 @@ RUN gradle bootJar --no-daemon
 FROM eclipse-temurin:21-jre
 RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /app/build/libs/*.jar app.jar
+ADD https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v2.4.0/opentelemetry-javaagent.jar /app/opentelemetry-javaagent.jar
 EXPOSE 8082
-CMD ["java", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-javaagent:/app/opentelemetry-javaagent.jar", "-jar", "app.jar"]

--- a/services/api-gateway/cmd/main.go
+++ b/services/api-gateway/cmd/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -15,7 +16,66 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/propagation"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
 )
+
+// ---------------------------------------------------------------------------
+// OpenTelemetry initialization
+// ---------------------------------------------------------------------------
+
+func initOTel(ctx context.Context, serviceName string) (func(), error) {
+	res, err := resource.New(ctx,
+		resource.WithAttributes(
+			semconv.ServiceName(serviceName),
+		),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create resource: %w", err)
+	}
+
+	traceExporter, err := otlptracegrpc.New(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create trace exporter: %w", err)
+	}
+
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithBatcher(traceExporter),
+		sdktrace.WithResource(res),
+	)
+	otel.SetTracerProvider(tp)
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	))
+
+	metricExporter, err := otlpmetricgrpc.New(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create metric exporter: %w", err)
+	}
+
+	mp := sdkmetric.NewMeterProvider(
+		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(metricExporter)),
+		sdkmetric.WithResource(res),
+	)
+	otel.SetMeterProvider(mp)
+
+	shutdown := func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = tp.Shutdown(shutdownCtx)
+		_ = mp.Shutdown(shutdownCtx)
+	}
+
+	return shutdown, nil
+}
 
 // ---------------------------------------------------------------------------
 // JSON logger
@@ -196,6 +256,7 @@ func newReverseProxy(target string) http.Handler {
 	}
 
 	proxy := httputil.NewSingleHostReverseProxy(targetURL)
+	proxy.Transport = otelhttp.NewTransport(http.DefaultTransport)
 
 	originalDirector := proxy.Director
 	proxy.Director = func(req *http.Request) {
@@ -234,6 +295,15 @@ func healthHandler(w http.ResponseWriter, r *http.Request) {
 // ---------------------------------------------------------------------------
 
 func main() {
+	ctx := context.Background()
+
+	shutdown, err := initOTel(ctx, "api-gateway")
+	if err != nil {
+		logger.Error("failed to initialize OpenTelemetry", map[string]string{"error": err.Error()})
+	} else {
+		defer shutdown()
+	}
+
 	authServiceURL := env("AUTH_SERVICE_URL", "http://auth-service:8081")
 	accountServiceURL := env("ACCOUNT_SERVICE_URL", "http://account-service:8082")
 	transactionServiceURL := env("TRANSACTION_SERVICE_URL", "http://transaction-service:8083")
@@ -248,8 +318,11 @@ func main() {
 
 	r := chi.NewRouter()
 
-	// Global metrics middleware
+	// Global middleware
 	r.Use(metricsMiddleware)
+	r.Use(func(next http.Handler) http.Handler {
+		return otelhttp.NewHandler(next, "api-gateway")
+	})
 
 	// ---- Public routes (no auth) ----
 	r.Get("/healthz", healthHandler)

--- a/services/api-gateway/cmd/main.go
+++ b/services/api-gateway/cmd/main.go
@@ -41,7 +41,9 @@ func initOTel(ctx context.Context, serviceName string) (func(), error) {
 		return nil, fmt.Errorf("failed to create resource: %w", err)
 	}
 
-	traceExporter, err := otlptracegrpc.New(ctx)
+	traceExporter, err := otlptracegrpc.New(ctx,
+		otlptracegrpc.WithInsecure(),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create trace exporter: %w", err)
 	}
@@ -56,7 +58,9 @@ func initOTel(ctx context.Context, serviceName string) (func(), error) {
 		propagation.Baggage{},
 	))
 
-	metricExporter, err := otlpmetricgrpc.New(ctx)
+	metricExporter, err := otlpmetricgrpc.New(ctx,
+		otlpmetricgrpc.WithInsecure(),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create metric exporter: %w", err)
 	}

--- a/services/api-gateway/cmd/main.go
+++ b/services/api-gateway/cmd/main.go
@@ -18,8 +18,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
-	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/propagation"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
@@ -41,8 +41,8 @@ func initOTel(ctx context.Context, serviceName string) (func(), error) {
 		return nil, fmt.Errorf("failed to create resource: %w", err)
 	}
 
-	traceExporter, err := otlptracegrpc.New(ctx,
-		otlptracegrpc.WithInsecure(),
+	traceExporter, err := otlptracehttp.New(ctx,
+		otlptracehttp.WithInsecure(),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create trace exporter: %w", err)
@@ -58,8 +58,8 @@ func initOTel(ctx context.Context, serviceName string) (func(), error) {
 		propagation.Baggage{},
 	))
 
-	metricExporter, err := otlpmetricgrpc.New(ctx,
-		otlpmetricgrpc.WithInsecure(),
+	metricExporter, err := otlpmetrichttp.New(ctx,
+		otlpmetrichttp.WithInsecure(),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create metric exporter: %w", err)

--- a/services/api-gateway/go.mod
+++ b/services/api-gateway/go.mod
@@ -5,16 +5,12 @@ go 1.22
 require (
 	github.com/go-chi/chi/v5 v5.1.0
 	github.com/prometheus/client_golang v1.20.5
-)
-
-require (
-	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/klauspost/compress v1.17.9 // indirect
-	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/prometheus/client_model v0.6.1 // indirect
-	github.com/prometheus/common v0.55.0 // indirect
-	github.com/prometheus/procfs v0.15.1 // indirect
-	golang.org/x/sys v0.22.0 // indirect
-	google.golang.org/protobuf v1.34.2 // indirect
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.52.0
+	go.opentelemetry.io/otel v1.27.0
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.27.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.27.0
+	go.opentelemetry.io/otel/propagation v1.27.0
+	go.opentelemetry.io/otel/sdk v1.27.0
+	go.opentelemetry.io/otel/sdk/metric v1.27.0
+	go.opentelemetry.io/otel/semconv v1.27.0
 )

--- a/services/api-gateway/go.mod
+++ b/services/api-gateway/go.mod
@@ -9,8 +9,6 @@ require (
 	go.opentelemetry.io/otel v1.27.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.27.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.27.0
-	go.opentelemetry.io/otel/propagation v1.27.0
 	go.opentelemetry.io/otel/sdk v1.27.0
 	go.opentelemetry.io/otel/sdk/metric v1.27.0
-	go.opentelemetry.io/otel/semconv v1.27.0
 )

--- a/services/api-gateway/go.mod
+++ b/services/api-gateway/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/prometheus/client_golang v1.20.5
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.52.0
 	go.opentelemetry.io/otel v1.27.0
-	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.27.0
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.27.0
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.27.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.27.0
 	go.opentelemetry.io/otel/propagation v1.27.0
 	go.opentelemetry.io/otel/sdk v1.27.0
 	go.opentelemetry.io/otel/sdk/metric v1.27.0

--- a/services/audit-service/Dockerfile
+++ b/services/audit-service/Dockerfile
@@ -7,5 +7,6 @@ RUN gradle bootJar --no-daemon
 FROM eclipse-temurin:21-jre
 RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /app/build/libs/*.jar app.jar
+ADD https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v2.4.0/opentelemetry-javaagent.jar /app/opentelemetry-javaagent.jar
 EXPOSE 8087
-CMD ["java", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-javaagent:/app/opentelemetry-javaagent.jar", "-jar", "app.jar"]

--- a/services/auth-service/cmd/main.go
+++ b/services/auth-service/cmd/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -15,7 +16,66 @@ import (
 	_ "github.com/lib/pq"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/propagation"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
 )
+
+// ---------------------------------------------------------------------------
+// OpenTelemetry initialization
+// ---------------------------------------------------------------------------
+
+func initOTel(ctx context.Context, serviceName string) (func(), error) {
+	res, err := resource.New(ctx,
+		resource.WithAttributes(
+			semconv.ServiceName(serviceName),
+		),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create resource: %w", err)
+	}
+
+	traceExporter, err := otlptracegrpc.New(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create trace exporter: %w", err)
+	}
+
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithBatcher(traceExporter),
+		sdktrace.WithResource(res),
+	)
+	otel.SetTracerProvider(tp)
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	))
+
+	metricExporter, err := otlpmetricgrpc.New(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create metric exporter: %w", err)
+	}
+
+	mp := sdkmetric.NewMeterProvider(
+		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(metricExporter)),
+		sdkmetric.WithResource(res),
+	)
+	otel.SetMeterProvider(mp)
+
+	shutdown := func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = tp.Shutdown(shutdownCtx)
+		_ = mp.Shutdown(shutdownCtx)
+	}
+
+	return shutdown, nil
+}
 
 // ---------------------------------------------------------------------------
 // Configuration
@@ -349,6 +409,15 @@ func handleReadyz(db *sql.DB) http.HandlerFunc {
 // ---------------------------------------------------------------------------
 
 func main() {
+	ctx := context.Background()
+
+	shutdown, err := initOTel(ctx, "auth-service")
+	if err != nil {
+		jsonLog("ERROR", fmt.Sprintf("failed to initialize OpenTelemetry: %v", err))
+	} else {
+		defer shutdown()
+	}
+
 	cfg := loadConfig()
 
 	jsonLog("INFO", "Starting auth-service")
@@ -358,6 +427,9 @@ func main() {
 
 	r := chi.NewRouter()
 	r.Use(metricsMiddleware)
+	r.Use(func(next http.Handler) http.Handler {
+		return otelhttp.NewHandler(next, "auth-service")
+	})
 
 	// Public API
 	r.Post("/api/v1/auth/register", handleRegister(db))

--- a/services/auth-service/cmd/main.go
+++ b/services/auth-service/cmd/main.go
@@ -41,7 +41,9 @@ func initOTel(ctx context.Context, serviceName string) (func(), error) {
 		return nil, fmt.Errorf("failed to create resource: %w", err)
 	}
 
-	traceExporter, err := otlptracegrpc.New(ctx)
+	traceExporter, err := otlptracegrpc.New(ctx,
+		otlptracegrpc.WithInsecure(),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create trace exporter: %w", err)
 	}
@@ -56,7 +58,9 @@ func initOTel(ctx context.Context, serviceName string) (func(), error) {
 		propagation.Baggage{},
 	))
 
-	metricExporter, err := otlpmetricgrpc.New(ctx)
+	metricExporter, err := otlpmetricgrpc.New(ctx,
+		otlpmetricgrpc.WithInsecure(),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create metric exporter: %w", err)
 	}

--- a/services/auth-service/cmd/main.go
+++ b/services/auth-service/cmd/main.go
@@ -18,8 +18,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
-	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/propagation"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
@@ -41,8 +41,8 @@ func initOTel(ctx context.Context, serviceName string) (func(), error) {
 		return nil, fmt.Errorf("failed to create resource: %w", err)
 	}
 
-	traceExporter, err := otlptracegrpc.New(ctx,
-		otlptracegrpc.WithInsecure(),
+	traceExporter, err := otlptracehttp.New(ctx,
+		otlptracehttp.WithInsecure(),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create trace exporter: %w", err)
@@ -58,8 +58,8 @@ func initOTel(ctx context.Context, serviceName string) (func(), error) {
 		propagation.Baggage{},
 	))
 
-	metricExporter, err := otlpmetricgrpc.New(ctx,
-		otlpmetricgrpc.WithInsecure(),
+	metricExporter, err := otlpmetrichttp.New(ctx,
+		otlpmetrichttp.WithInsecure(),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create metric exporter: %w", err)

--- a/services/auth-service/go.mod
+++ b/services/auth-service/go.mod
@@ -9,8 +9,8 @@ require (
 	github.com/prometheus/client_golang v1.19.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.52.0
 	go.opentelemetry.io/otel v1.27.0
-	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.27.0
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.27.0
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.27.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.27.0
 	go.opentelemetry.io/otel/propagation v1.27.0
 	go.opentelemetry.io/otel/sdk v1.27.0
 	go.opentelemetry.io/otel/sdk/metric v1.27.0

--- a/services/auth-service/go.mod
+++ b/services/auth-service/go.mod
@@ -11,8 +11,6 @@ require (
 	go.opentelemetry.io/otel v1.27.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.27.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.27.0
-	go.opentelemetry.io/otel/propagation v1.27.0
 	go.opentelemetry.io/otel/sdk v1.27.0
 	go.opentelemetry.io/otel/sdk/metric v1.27.0
-	go.opentelemetry.io/otel/semconv v1.27.0
 )

--- a/services/auth-service/go.mod
+++ b/services/auth-service/go.mod
@@ -7,14 +7,12 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/lib/pq v1.10.9
 	github.com/prometheus/client_golang v1.19.0
-)
-
-require (
-	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/cespare/xxhash/v2 v2.2.0 // indirect
-	github.com/prometheus/client_model v0.6.0 // indirect
-	github.com/prometheus/common v0.48.0 // indirect
-	github.com/prometheus/procfs v0.12.0 // indirect
-	golang.org/x/sys v0.17.0 // indirect
-	google.golang.org/protobuf v1.32.0 // indirect
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.52.0
+	go.opentelemetry.io/otel v1.27.0
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.27.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.27.0
+	go.opentelemetry.io/otel/propagation v1.27.0
+	go.opentelemetry.io/otel/sdk v1.27.0
+	go.opentelemetry.io/otel/sdk/metric v1.27.0
+	go.opentelemetry.io/otel/semconv v1.27.0
 )

--- a/services/exchange-service/main.py
+++ b/services/exchange-service/main.py
@@ -14,10 +14,10 @@ from prometheus_fastapi_instrumentator import Instrumentator
 from opentelemetry import trace, metrics
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
-from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
-from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
+from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 
@@ -56,10 +56,10 @@ otel_resource = Resource.create({
 })
 
 tracer_provider = TracerProvider(resource=otel_resource)
-tracer_provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter(insecure=True)))
+tracer_provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
 trace.set_tracer_provider(tracer_provider)
 
-metric_reader = PeriodicExportingMetricReader(OTLPMetricExporter(insecure=True))
+metric_reader = PeriodicExportingMetricReader(OTLPMetricExporter())
 meter_provider = MeterProvider(resource=otel_resource, metric_readers=[metric_reader])
 metrics.set_meter_provider(meter_provider)
 

--- a/services/exchange-service/main.py
+++ b/services/exchange-service/main.py
@@ -56,10 +56,10 @@ otel_resource = Resource.create({
 })
 
 tracer_provider = TracerProvider(resource=otel_resource)
-tracer_provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+tracer_provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter(insecure=True)))
 trace.set_tracer_provider(tracer_provider)
 
-metric_reader = PeriodicExportingMetricReader(OTLPMetricExporter())
+metric_reader = PeriodicExportingMetricReader(OTLPMetricExporter(insecure=True))
 meter_provider = MeterProvider(resource=otel_resource, metric_readers=[metric_reader])
 metrics.set_meter_provider(meter_provider)
 

--- a/services/exchange-service/main.py
+++ b/services/exchange-service/main.py
@@ -51,9 +51,11 @@ logger = logging.getLogger("exchange-service")
 # OpenTelemetry initialization
 # ---------------------------------------------------------------------------
 
-otel_resource = Resource.create({
-    "service.name": os.environ.get("OTEL_SERVICE_NAME", "exchange-service"),
-})
+otel_resource = Resource.create(
+    {
+        "service.name": os.environ.get("OTEL_SERVICE_NAME", "exchange-service"),
+    }
+)
 
 tracer_provider = TracerProvider(resource=otel_resource)
 tracer_provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))

--- a/services/exchange-service/main.py
+++ b/services/exchange-service/main.py
@@ -11,6 +11,16 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 from prometheus_fastapi_instrumentator import Instrumentator
 
+from opentelemetry import trace, metrics
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+
 
 # ---------------------------------------------------------------------------
 # JSON logging setup
@@ -36,6 +46,22 @@ logging.root.handlers = [handler]
 logging.root.setLevel(logging.INFO)
 
 logger = logging.getLogger("exchange-service")
+
+# ---------------------------------------------------------------------------
+# OpenTelemetry initialization
+# ---------------------------------------------------------------------------
+
+otel_resource = Resource.create({
+    "service.name": os.environ.get("OTEL_SERVICE_NAME", "exchange-service"),
+})
+
+tracer_provider = TracerProvider(resource=otel_resource)
+tracer_provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+trace.set_tracer_provider(tracer_provider)
+
+metric_reader = PeriodicExportingMetricReader(OTLPMetricExporter())
+meter_provider = MeterProvider(resource=otel_resource, metric_readers=[metric_reader])
+metrics.set_meter_provider(meter_provider)
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -65,6 +91,7 @@ app = FastAPI(
 )
 
 Instrumentator().instrument(app).expose(app, endpoint="/metrics")
+FastAPIInstrumentor.instrument_app(app)
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/services/exchange-service/requirements.txt
+++ b/services/exchange-service/requirements.txt
@@ -6,4 +6,4 @@ opentelemetry-sdk==1.25.0
 opentelemetry-exporter-otlp==1.25.0
 opentelemetry-instrumentation-fastapi==0.46b0
 opentelemetry-instrumentation-logging==0.46b0
-setuptools>=70.0.0
+setuptools>=70.0.0,<81

--- a/services/exchange-service/requirements.txt
+++ b/services/exchange-service/requirements.txt
@@ -6,3 +6,4 @@ opentelemetry-sdk==1.25.0
 opentelemetry-exporter-otlp==1.25.0
 opentelemetry-instrumentation-fastapi==0.46b0
 opentelemetry-instrumentation-logging==0.46b0
+setuptools>=70.0.0

--- a/services/exchange-service/requirements.txt
+++ b/services/exchange-service/requirements.txt
@@ -1,3 +1,8 @@
 fastapi==0.111.0
 uvicorn==0.30.0
 prometheus-fastapi-instrumentator==7.0.0
+opentelemetry-api==1.25.0
+opentelemetry-sdk==1.25.0
+opentelemetry-exporter-otlp==1.25.0
+opentelemetry-instrumentation-fastapi==0.46b0
+opentelemetry-instrumentation-logging==0.46b0

--- a/services/fraud-service/cmd/main.go
+++ b/services/fraud-service/cmd/main.go
@@ -17,8 +17,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
-	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/propagation"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
@@ -40,8 +40,8 @@ func initOTel(ctx context.Context, serviceName string) (func(), error) {
 		return nil, fmt.Errorf("failed to create resource: %w", err)
 	}
 
-	traceExporter, err := otlptracegrpc.New(ctx,
-		otlptracegrpc.WithInsecure(),
+	traceExporter, err := otlptracehttp.New(ctx,
+		otlptracehttp.WithInsecure(),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create trace exporter: %w", err)
@@ -57,8 +57,8 @@ func initOTel(ctx context.Context, serviceName string) (func(), error) {
 		propagation.Baggage{},
 	))
 
-	metricExporter, err := otlpmetricgrpc.New(ctx,
-		otlpmetricgrpc.WithInsecure(),
+	metricExporter, err := otlpmetrichttp.New(ctx,
+		otlpmetrichttp.WithInsecure(),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create metric exporter: %w", err)

--- a/services/fraud-service/cmd/main.go
+++ b/services/fraud-service/cmd/main.go
@@ -40,7 +40,9 @@ func initOTel(ctx context.Context, serviceName string) (func(), error) {
 		return nil, fmt.Errorf("failed to create resource: %w", err)
 	}
 
-	traceExporter, err := otlptracegrpc.New(ctx)
+	traceExporter, err := otlptracegrpc.New(ctx,
+		otlptracegrpc.WithInsecure(),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create trace exporter: %w", err)
 	}
@@ -55,7 +57,9 @@ func initOTel(ctx context.Context, serviceName string) (func(), error) {
 		propagation.Baggage{},
 	))
 
-	metricExporter, err := otlpmetricgrpc.New(ctx)
+	metricExporter, err := otlpmetricgrpc.New(ctx,
+		otlpmetricgrpc.WithInsecure(),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create metric exporter: %w", err)
 	}

--- a/services/fraud-service/cmd/main.go
+++ b/services/fraud-service/cmd/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -14,7 +15,66 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/propagation"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
 )
+
+// ---------------------------------------------------------------------------
+// OpenTelemetry initialization
+// ---------------------------------------------------------------------------
+
+func initOTel(ctx context.Context, serviceName string) (func(), error) {
+	res, err := resource.New(ctx,
+		resource.WithAttributes(
+			semconv.ServiceName(serviceName),
+		),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create resource: %w", err)
+	}
+
+	traceExporter, err := otlptracegrpc.New(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create trace exporter: %w", err)
+	}
+
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithBatcher(traceExporter),
+		sdktrace.WithResource(res),
+	)
+	otel.SetTracerProvider(tp)
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	))
+
+	metricExporter, err := otlpmetricgrpc.New(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create metric exporter: %w", err)
+	}
+
+	mp := sdkmetric.NewMeterProvider(
+		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(metricExporter)),
+		sdkmetric.WithResource(res),
+	)
+	otel.SetMeterProvider(mp)
+
+	shutdown := func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = tp.Shutdown(shutdownCtx)
+		_ = mp.Shutdown(shutdownCtx)
+	}
+
+	return shutdown, nil
+}
 
 // ---------- Prometheus metrics ----------
 
@@ -265,6 +325,15 @@ func writeError(w http.ResponseWriter, status int, code, message string) {
 // ---------- Main ----------
 
 func main() {
+	ctx := context.Background()
+
+	shutdown, err := initOTel(ctx, "fraud-service")
+	if err != nil {
+		logJSON("ERROR", fmt.Sprintf("failed to initialize OpenTelemetry: %v", err))
+	} else {
+		defer shutdown()
+	}
+
 	port := os.Getenv("PORT")
 	if port == "" {
 		port = "8084"
@@ -272,6 +341,9 @@ func main() {
 
 	r := chi.NewRouter()
 	r.Use(metricsMiddleware)
+	r.Use(func(next http.Handler) http.Handler {
+		return otelhttp.NewHandler(next, "fraud-service")
+	})
 
 	r.Get("/healthz", healthHandler)
 	r.Post("/api/v1/fraud/check", fraudCheckHandler)

--- a/services/fraud-service/go.mod
+++ b/services/fraud-service/go.mod
@@ -5,14 +5,12 @@ go 1.22
 require (
 	github.com/go-chi/chi/v5 v5.0.12
 	github.com/prometheus/client_golang v1.19.0
-)
-
-require (
-	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/cespare/xxhash/v2 v2.2.0 // indirect
-	github.com/prometheus/client_model v0.6.0 // indirect
-	github.com/prometheus/common v0.48.0 // indirect
-	github.com/prometheus/procfs v0.12.0 // indirect
-	golang.org/x/sys v0.16.0 // indirect
-	google.golang.org/protobuf v1.32.0 // indirect
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.52.0
+	go.opentelemetry.io/otel v1.27.0
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.27.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.27.0
+	go.opentelemetry.io/otel/propagation v1.27.0
+	go.opentelemetry.io/otel/sdk v1.27.0
+	go.opentelemetry.io/otel/sdk/metric v1.27.0
+	go.opentelemetry.io/otel/semconv v1.27.0
 )

--- a/services/fraud-service/go.mod
+++ b/services/fraud-service/go.mod
@@ -9,8 +9,6 @@ require (
 	go.opentelemetry.io/otel v1.27.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.27.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.27.0
-	go.opentelemetry.io/otel/propagation v1.27.0
 	go.opentelemetry.io/otel/sdk v1.27.0
 	go.opentelemetry.io/otel/sdk/metric v1.27.0
-	go.opentelemetry.io/otel/semconv v1.27.0
 )

--- a/services/fraud-service/go.mod
+++ b/services/fraud-service/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/prometheus/client_golang v1.19.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.52.0
 	go.opentelemetry.io/otel v1.27.0
-	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.27.0
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.27.0
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.27.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.27.0
 	go.opentelemetry.io/otel/propagation v1.27.0
 	go.opentelemetry.io/otel/sdk v1.27.0
 	go.opentelemetry.io/otel/sdk/metric v1.27.0

--- a/services/notification-service/main.py
+++ b/services/notification-service/main.py
@@ -11,6 +11,16 @@ from fastapi.responses import JSONResponse
 from prometheus_fastapi_instrumentator import Instrumentator
 from pydantic import BaseModel, Field
 
+from opentelemetry import trace, metrics
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+
 # ---------------------------------------------------------------------------
 # JSON logging to stdout
 # ---------------------------------------------------------------------------
@@ -35,6 +45,22 @@ logging.root.handlers = [handler]
 logging.root.setLevel(logging.INFO)
 
 logger = logging.getLogger("notification-service")
+
+# ---------------------------------------------------------------------------
+# OpenTelemetry initialization
+# ---------------------------------------------------------------------------
+
+otel_resource = Resource.create({
+    "service.name": os.environ.get("OTEL_SERVICE_NAME", "notification-service"),
+})
+
+tracer_provider = TracerProvider(resource=otel_resource)
+tracer_provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+trace.set_tracer_provider(tracer_provider)
+
+metric_reader = PeriodicExportingMetricReader(OTLPMetricExporter())
+meter_provider = MeterProvider(resource=otel_resource, metric_readers=[metric_reader])
+metrics.set_meter_provider(meter_provider)
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -98,6 +124,7 @@ app = FastAPI(
 
 # Prometheus metrics
 Instrumentator().instrument(app).expose(app, endpoint="/metrics")
+FastAPIInstrumentor.instrument_app(app)
 
 # ---------------------------------------------------------------------------
 # Exception handlers

--- a/services/notification-service/main.py
+++ b/services/notification-service/main.py
@@ -55,10 +55,10 @@ otel_resource = Resource.create({
 })
 
 tracer_provider = TracerProvider(resource=otel_resource)
-tracer_provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+tracer_provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter(insecure=True)))
 trace.set_tracer_provider(tracer_provider)
 
-metric_reader = PeriodicExportingMetricReader(OTLPMetricExporter())
+metric_reader = PeriodicExportingMetricReader(OTLPMetricExporter(insecure=True))
 meter_provider = MeterProvider(resource=otel_resource, metric_readers=[metric_reader])
 metrics.set_meter_provider(meter_provider)
 

--- a/services/notification-service/main.py
+++ b/services/notification-service/main.py
@@ -50,9 +50,11 @@ logger = logging.getLogger("notification-service")
 # OpenTelemetry initialization
 # ---------------------------------------------------------------------------
 
-otel_resource = Resource.create({
-    "service.name": os.environ.get("OTEL_SERVICE_NAME", "notification-service"),
-})
+otel_resource = Resource.create(
+    {
+        "service.name": os.environ.get("OTEL_SERVICE_NAME", "notification-service"),
+    }
+)
 
 tracer_provider = TracerProvider(resource=otel_resource)
 tracer_provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))

--- a/services/notification-service/main.py
+++ b/services/notification-service/main.py
@@ -14,10 +14,10 @@ from pydantic import BaseModel, Field
 from opentelemetry import trace, metrics
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
-from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
-from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
+from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 
@@ -55,10 +55,10 @@ otel_resource = Resource.create({
 })
 
 tracer_provider = TracerProvider(resource=otel_resource)
-tracer_provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter(insecure=True)))
+tracer_provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
 trace.set_tracer_provider(tracer_provider)
 
-metric_reader = PeriodicExportingMetricReader(OTLPMetricExporter(insecure=True))
+metric_reader = PeriodicExportingMetricReader(OTLPMetricExporter())
 meter_provider = MeterProvider(resource=otel_resource, metric_readers=[metric_reader])
 metrics.set_meter_provider(meter_provider)
 

--- a/services/notification-service/requirements.txt
+++ b/services/notification-service/requirements.txt
@@ -6,4 +6,4 @@ opentelemetry-sdk==1.25.0
 opentelemetry-exporter-otlp==1.25.0
 opentelemetry-instrumentation-fastapi==0.46b0
 opentelemetry-instrumentation-logging==0.46b0
-setuptools>=70.0.0
+setuptools>=70.0.0,<81

--- a/services/notification-service/requirements.txt
+++ b/services/notification-service/requirements.txt
@@ -6,3 +6,4 @@ opentelemetry-sdk==1.25.0
 opentelemetry-exporter-otlp==1.25.0
 opentelemetry-instrumentation-fastapi==0.46b0
 opentelemetry-instrumentation-logging==0.46b0
+setuptools>=70.0.0

--- a/services/notification-service/requirements.txt
+++ b/services/notification-service/requirements.txt
@@ -1,3 +1,8 @@
 fastapi==0.111.0
 uvicorn==0.30.0
 prometheus-fastapi-instrumentator==7.0.0
+opentelemetry-api==1.25.0
+opentelemetry-sdk==1.25.0
+opentelemetry-exporter-otlp==1.25.0
+opentelemetry-instrumentation-fastapi==0.46b0
+opentelemetry-instrumentation-logging==0.46b0

--- a/services/transaction-service/Dockerfile
+++ b/services/transaction-service/Dockerfile
@@ -7,5 +7,6 @@ RUN gradle bootJar --no-daemon
 FROM eclipse-temurin:21-jre
 RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /app/build/libs/*.jar app.jar
+ADD https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v2.4.0/opentelemetry-javaagent.jar /app/opentelemetry-javaagent.jar
 EXPOSE 8083
-CMD ["java", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-javaagent:/app/opentelemetry-javaagent.jar", "-jar", "app.jar"]


### PR DESCRIPTION
## Summary

- New Helm chart `helm/otel/` with OTel Collector (OTLP receiver → Honeycomb exporter) and Istio sidecar support
- Instrumented all 8 services with OTel SDKs: Go (manual SDK + otelhttp), JVM (Java Agent), Python (SDK + FastAPIInstrumentor)
- Updated microbank Helm chart with `global.otel.enabled` to auto-inject OTel env vars into all service deployments
- Existing Prometheus + Grafana stack is untouched

Closes #16

## Test plan

- [ ] `helm template` renders both `helm/otel/` and `helm/microbank/` without errors
- [ ] Deploy OTel Collector: `helm install otel ./helm/otel/ -n student-research --set honeycomb.apiKey=<key>`
- [ ] Deploy services: `helm upgrade --install microbank ./helm/microbank/ -n student-research`
- [ ] Verify OTel Collector pod is healthy and has Istio sidecar
- [ ] Trigger a transfer flow and verify distributed trace in Honeycomb
- [ ] Confirm Prometheus metrics endpoints still work
- [ ] Test with `global.otel.enabled=false` to verify clean disable