### PR TITLE
Convert PostgreSQL Deployment to StatefulSet with PVC

### DIFF
--- a/helm/microbank/charts/postgres/templates/statefulset.yaml
+++ b/helm/microbank/charts/postgres/templates/statefulset.yaml
@@ -1,14 +1,13 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ include "postgres.fullname" . }}
   namespace: {{ .Values.global.namespace }}
   labels:
     {{- include "postgres.labels" . | nindent 4 }}
 spec:
+  serviceName: {{ include "postgres.fullname" . }}
   replicas: 1
-  strategy:
-    type: Recreate
   selector:
     matchLabels:
       {{- include "postgres.selectorLabels" . | nindent 6 }}
@@ -64,8 +63,17 @@ spec:
             - name: init-scripts
               mountPath: /docker-entrypoint-initdb.d
       volumes:
-        - name: data
-          emptyDir: {}
         - name: init-scripts
           configMap:
             name: {{ include "postgres.fullname" . }}-init
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        {{- if .Values.storage.storageClass }}
+        storageClassName: {{ .Values.storage.storageClass }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.storage.size }}

--- a/helm/microbank/charts/postgres/values.yaml
+++ b/helm/microbank/charts/postgres/values.yaml
@@ -1,5 +1,5 @@
 storage:
-  size: 1Gi
+  size: 512Mi
   storageClass: ""
 
 resources:


### PR DESCRIPTION
Closes #18

## Summary

- Replaced `kind: Deployment` with `kind: StatefulSet` in `helm/microbank/charts/postgres/templates/statefulset.yaml`
- Added `volumeClaimTemplates` — Kubernetes automatically creates a PVC (`data-<release>-postgres-0`) backed by an EBS volume on EKS
- Removed `emptyDir` ephemeral storage; data now survives pod restarts and rescheduling
- Reduced default PVC size to `512Mi` in `values.yaml`
- `storageClass` remains configurable (empty = cluster default)

## Test plan

- [ ] `helm template` renders a valid StatefulSet manifest
- [ ] `helm install` on EKS creates the PVC and binds it to an EBS volume
- [ ] PostgreSQL data persists after `kubectl delete pod`

Co-Authored-By: Claude